### PR TITLE
Remove defaultInterpreterPath from VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "python.defaultInterpreterPath": "${workspaceFolder}/venv/bin/python",
   "editor.formatOnSave": true,
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter",


### PR DESCRIPTION
The fix for the interpreter path warning missed the PR #2 merge window — the commit was pushed after the PR was already merged. This removes the `python.defaultInterpreterPath` setting that was causing the VS Code warning. VS Code auto-discovers the `venv/` folder at the workspace root without needing an explicit path.