### PR TITLE
setup: prefer gh CLI for git operations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,7 @@ requirements.txt
   - `docs/` — documentation only
 - CI must pass (lint + tests) before a PR can be merged.
 - Keep PRs focused. One logical change per PR.
+- Use the `gh` CLI for all git operations (branch creation, push, PR creation). Do not use GitKraken or other MCP-based git tools.
 
 ## Code style
 


### PR DESCRIPTION
Documents the preference to use the `gh` CLI for all git operations (branch creation, push, PR creation) rather than GitKraken or other MCP-based git tools.