### PR TITLE
setup: enable Dependabot for pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- Enables Dependabot vulnerability alerts on the repo
- Adds `.github/dependabot.yml` to generate automatic PRs for vulnerable or outdated pip dependencies (weekly schedule)